### PR TITLE
Add global javadoc symbol and update markdown formatting

### DIFF
--- a/DaedalusBuiltins/G1/gothic.d
+++ b/DaedalusBuiltins/G1/gothic.d
@@ -1765,7 +1765,7 @@ func void TA_RemoveOverlay(var C_NPC npc) {};
 ///
 /// @param room name of the room as defined in the portal
 /// @param guild guild ID
-func void AssignRoomToGuild(var string room, var int guild) {};
+func void Wld_AssignRoomToGuild(var string room, var int guild) {};
 
 /// Assigns a room to a specific NPC
 ///

--- a/DaedalusBuiltins/G2A/gothic.d
+++ b/DaedalusBuiltins/G2A/gothic.d
@@ -1903,7 +1903,7 @@ func void TA_RemoveOverlay(var C_NPC npc) {};
 ///
 /// @param room name of the room as defined in the portal
 /// @param guild guild ID
-func void AssignRoomToGuild(var string room, var int guild) {};
+func void Wld_AssignRoomToGuild(var string room, var int guild) {};
 
 /// Assigns a room to a specific NPC
 ///

--- a/javadoc/javadoc.go
+++ b/javadoc/javadoc.go
@@ -47,9 +47,9 @@ func formatGlobal(sb *strings.Builder, line string) {
 }
 
 func formatParams(sb *strings.Builder, param, desc string) {
-	sb.WriteString("- **")
+	sb.WriteString("- `")
 	appendMarkdownEscaped(sb, param)
-	sb.WriteString("** - *")
+	sb.WriteString("` - *")
 
 	const (
 		PREFIX_INST = "{"

--- a/javadoc/javadoc.go
+++ b/javadoc/javadoc.go
@@ -9,12 +9,14 @@ import (
 )
 
 var (
+	javadocGlobal = []byte("@global")
 	javadocParam  = []byte("@param")
 	javadocReturn = []byte("@return")
 )
 
 type javadoc struct {
 	Summary    string
+	Globals    string
 	Parameters string
 	Return     string
 }
@@ -26,6 +28,22 @@ func appendMarkdownEscaped(sb *strings.Builder, text string) {
 		}
 		sb.WriteRune(v)
 	}
+}
+
+func formatGlobal(sb *strings.Builder, line string) {
+	name, desc, ok := strings.Cut(line, " ")
+	if ok {
+		name = strings.TrimSpace(name)
+		sb.WriteString("- `")
+		sb.WriteString(name)
+		sb.WriteString("` - ")
+		appendMarkdownEscaped(sb, desc)
+		sb.WriteString("   \n")
+	} else {
+		appendMarkdownEscaped(sb, line)
+		sb.WriteString("   \n")
+	}
+
 }
 
 func formatParams(sb *strings.Builder, param, desc string) {
@@ -109,6 +127,7 @@ func parseJavadocMdEscaped(sym symbol.Symbol) javadoc {
 	}
 
 	summary := strings.Builder{}
+	globals := strings.Builder{}
 	params := strings.Builder{}
 	returns := strings.Builder{}
 
@@ -131,12 +150,19 @@ func parseJavadocMdEscaped(sym symbol.Symbol) javadoc {
 					break
 				}
 			}
+		} else if bytes.HasPrefix(line, javadocGlobal) {
+			line = bytes.TrimSpace(bytes.TrimPrefix(line, javadocGlobal))
+			formatGlobal(&globals, string(line))
 		} else {
 			appendMarkdownEscaped(&summary, string(line))
 			summary.WriteString("  \n")
 		}
 	}
 	r.Summary = strings.TrimSpace(summary.String())
+	if r.Globals != "" {
+		globals.WriteString("\n")
+	}
+	r.Globals = strings.TrimSpace(globals.String())
 	r.Parameters = strings.TrimSpace(params.String())
 	r.Return = strings.TrimSpace(returns.String())
 	return r
@@ -153,7 +179,15 @@ func Markdown(doc javadoc) string {
 	sb.WriteString(doc.Summary)
 	sb.WriteString("\n")
 	sb.WriteString("\n")
-	sb.WriteString(doc.Parameters)
+	if doc.Globals != "" {
+		sb.WriteString("### Globals\n")
+		sb.WriteString(doc.Globals)
+		sb.WriteString("\n")
+	}
+	if doc.Parameters != "" {
+		sb.WriteString("### Parameters\n")
+		sb.WriteString(doc.Parameters)
+	}
 	if doc.Return != "" {
 		sb.WriteString("\n\n*returns ")
 		sb.WriteString(doc.Return)

--- a/javadoc/javadoc_test.go
+++ b/javadoc/javadoc_test.go
@@ -21,7 +21,7 @@ func TestJavadocParam(t *testing.T) {
 
 	jd := javadoc.MarkdownSimple(s)
 
-	if !strings.Contains(jd, "- **p** - *decides things*") {
+	if !strings.Contains(jd, "- `p` - *decides things*") {
 		t.Fatalf("expected markdown property content, actual: %s", jd)
 	}
 }
@@ -48,7 +48,7 @@ func TestJavadocParamWithParser(t *testing.T) {
 
 	jd := javadoc.MarkdownSimple(fn)
 
-	if !strings.Contains(jd, "- **amount** - *the amount*") {
+	if !strings.Contains(jd, "- `amount` - *the amount*") {
 		t.Fatalf("expected markdown property content, actual: %s", jd)
 	}
 }


### PR DESCRIPTION
Functions that change global variables could now be properly described, also the headers were added to improve readability.
```
/// Inserts an NPC into the world at the specified spawn point
///
/// @global self set to the inserted NPC
/// @param npcinstance instance ID of the NPC
/// @param spawnpoint name of the spawn point (waypoint or object)
func void Wld_InsertNpc(var int npcinstance, var string spawnpoint) {};
```

![obraz](https://github.com/user-attachments/assets/1aa15d18-1b96-4d23-b445-db139a497e15)
